### PR TITLE
Bug in loop counter

### DIFF
--- a/Dell_iDRAC_fan_controller.sh
+++ b/Dell_iDRAC_fan_controller.sh
@@ -231,6 +231,6 @@ while true; do
     i=0
   fi
   printf "%19s  %3d°C  %3d°C  %3s°C  %5s°C  %40s  %51s  %s\n" "$(date +"%d-%m-%Y %T")" $INLET_TEMPERATURE $CPU1_TEMPERATURE "$CPU2_TEMPERATURE" "$EXHAUST_TEMPERATURE" "$CURRENT_FAN_CONTROL_PROFILE" "$THIRD_PARTY_PCIE_CARD_DELL_DEFAULT_COOLING_RESPONSE_STATUS" "$COMMENT"
-  ((i++))
+  ((++i))
   wait $SLEEP_PROCESS_PID
 done


### PR DESCRIPTION
The increment fails because of the addition of 
'set -euo pipefail'.  Using ((++i)) instead
will evaluate after the increment and will work